### PR TITLE
set alt text on badges screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # myuw-badge
 
-![alt text](badges.png "Badge themes")
+![Screenshot showing 'Find it in MyUW' badge in each of the themes. A Madison-red theme including the Madison crest. A black theme with only the bare 'Find it in MyUW' text](badges.png "Badge themes")
 
 A badge with two available themes to help users discover new widgets and content in MyUW.
 


### PR DESCRIPTION
Sets the alt text on the screenshot of the badges.

Without this change, apparently a browser would narrate that screenshot as "alt text".

With this change, it should narrate it with a description of the meaning that is being visually conveyed.

Before:

<img width="871" alt="Screenshot of Firefox accessibility tree showing screenshot would be narrated as quote alt text end quote" src="https://user-images.githubusercontent.com/952283/57855585-9b99ad00-77b0-11e9-8688-e1910c2567ef.png">
